### PR TITLE
Add custom exceptions to handle errors in AuditoriumSource

### DIFF
--- a/src/main/java/com/epam/rd/movietheater/service/auditorium/source/AuditoriumSourceFileNotPresentException.java
+++ b/src/main/java/com/epam/rd/movietheater/service/auditorium/source/AuditoriumSourceFileNotPresentException.java
@@ -1,0 +1,7 @@
+package com.epam.rd.movietheater.service.auditorium.source;
+
+public class AuditoriumSourceFileNotPresentException extends RuntimeException {
+    public AuditoriumSourceFileNotPresentException(String fileName) {
+        super("File '" + fileName + "' is not present in classpath");
+    }
+}

--- a/src/main/java/com/epam/rd/movietheater/service/auditorium/source/PropertyBasedAuditoriumSource.java
+++ b/src/main/java/com/epam/rd/movietheater/service/auditorium/source/PropertyBasedAuditoriumSource.java
@@ -33,18 +33,24 @@ public class PropertyBasedAuditoriumSource implements AuditoriumSource {
             Properties props = PropertiesLoaderUtils.loadProperties(resource);
             auditoriums = fetchAuditoriums(props);
         } catch (IOException ex) {
-            throw new RuntimeException(ex);
+            throw new AuditoriumSourceFileNotPresentException(fileName);
         }
     }
+
     private Set<Auditorium> fetchAuditoriums(Properties props) {
         return props.entrySet().stream()
                 .map(e -> mapFromEntry(e))
                 .collect(toSet());
     }
+
     private Auditorium mapFromEntry(Map.Entry<Object, Object> entry) {
-        String name = ((String)entry.getKey()).replace('_',' ');
-        Auditorium newAuditorium = gson.fromJson((String)entry.getValue(), Auditorium.class);
-        newAuditorium.setName(name);
-        return newAuditorium;
+        String name = ((String) entry.getKey()).replace('_', ' ');
+        try {
+            Auditorium newAuditorium = gson.fromJson((String) entry.getValue(), Auditorium.class);
+            newAuditorium.setName(name);
+            return newAuditorium;
+        } catch (Exception ex) {
+            throw new WrongAuditoriumSourceFileFormatException("invalid json");
+        }
     }
 }

--- a/src/main/java/com/epam/rd/movietheater/service/auditorium/source/WrongAuditoriumSourceFileFormatException.java
+++ b/src/main/java/com/epam/rd/movietheater/service/auditorium/source/WrongAuditoriumSourceFileFormatException.java
@@ -1,0 +1,7 @@
+package com.epam.rd.movietheater.service.auditorium.source;
+
+public class WrongAuditoriumSourceFileFormatException extends RuntimeException {
+    public WrongAuditoriumSourceFileFormatException(String cause) {
+        super("Cannot parse target file: " + cause);
+    }
+}


### PR DESCRIPTION
PropertyBasedAuditoriumSource may encounter some errors (property file not found, json cannot be parsed). Need to create exceptions to handle them.